### PR TITLE
Fix to error and warning in compiling with clang/macOS

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -17,7 +17,7 @@ extern double xmc;
 extern double tmax;
 extern double p;  // Non-dimensionalized ymc [p=ymc/c]
 extern double q;  // Non-dimensionalized xmc [q=xmc/c]
-extern double tm;
+extern double t_m;
 extern double trailing_edge_type;  // 1 = open, else closed
 
 // Test conditions in water tunnel

--- a/src/NewtonRaphsonNonLinear.cpp
+++ b/src/NewtonRaphsonNonLinear.cpp
@@ -2,7 +2,7 @@
 #include "VectorOperations.h"
 #include "InfluenceMatrix.h"
 #include "velocity.h"
-#include "NewtonRaphsonNonlinear.h"
+#include "NewtonRaphsonNonLinear.h"
 
 
 /*this function returns the residuals */

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -7,7 +7,7 @@ double xmc = 0;           // 2nd digit of NACA 4 digit series airfoil
 double tmax = 12;         // last two digits of NACA 4 digit series airfoil
 double p = (ymc / 100.0); // p non dimensionalised ymc [p=ymc/c]
 double q = (xmc * 0.1);   // q non dimensionalised xmc [q=xmc/c]
-double tm = (tmax / 100.0);
+double t_m = (tmax / 100.0);
 double trailing_edge_type = 2; // if (trailing_edge_type ==1 ==> open ; else ==> closed)
 
 // Test conditions in water tunnel 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -25,11 +25,11 @@ MatrixXd geometry(double x_c)
     }
     if (trailing_edge_type == 1.0) // 1 indicates open trailing edge
     {
-        t = c * (tm * (2.969 * sqrt(x_c) - 1.260 * (x_c)-3.516 * pow((x_c), 2) + 2.843 * pow((x_c), 3.0) - 1.015 * (pow((x_c), 4.0))));
+        t = c * (t_m * (2.969 * sqrt(x_c) - 1.260 * (x_c)-3.516 * pow((x_c), 2) + 2.843 * pow((x_c), 3.0) - 1.015 * (pow((x_c), 4.0))));
     }
     else
     {
-        t = c * (tm * (2.980 * sqrt(x_c) - 1.320 * (x_c)-3.286 * pow((x_c), 2) + 2.441 * pow((x_c), 3.0) - 0.815 * (pow((x_c), 4.0))));
+        t = c * (t_m * (2.980 * sqrt(x_c) - 1.320 * (x_c)-3.286 * pow((x_c), 2) + 2.441 * pow((x_c), 3.0) - 0.815 * (pow((x_c), 4.0))));
     }
     if (p == 0.0) //[SYMMETRIC AIRFOIL]
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@
 #include "kinematics.h"
 #include "InfluenceMatrix.h"
 #include "Amatrix.h"
-#include "NewtonRaphsonNonlinear.h"
+#include "NewtonRaphsonNonLinear.h"
 #include "velocity.h"
 #include "gnuplot.h"
 


### PR DESCRIPTION
This PR fixes:

> src/geometry.cpp:28:18: error: reference to 'tm' is ambiguous
>    28 |         t = c * (tm * (2.969 * sqrt(x_c) - 1.260 * (x_c)-3.516 * pow((x_c), 2) + 2.843 * pow((x_c), 3.0) - 1.015 * (pow((x_c), 4.0))));
>       |                  ^
> include/constants.h:20:15: note: candidate found by name lookup is 'tm'
>    20 | extern double tm;
>       |               ^
> /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/ctime:67:9: note: candidate found by name lookup is 'std::tm'
>    67 | using ::tm _LIBCPP_USING_IF_EXISTS;

and:

> src/NewtonRaphsonNonLinear.cpp:5:10: warning: non-portable path to file '"NewtonRaphsonNonLinear.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
>     5 | #include "NewtonRaphsonNonlinear.h"
>       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
>       |          "NewtonRaphsonNonLinear.h"

Related to https://github.com/openjournals/joss-reviews/issues/8865